### PR TITLE
Fix for start script and dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -27,11 +27,20 @@ Welcome to OPay!
 
 ## How to run
 
-To get and run:
+To download, please clone it from github:
 
 ```bash
 git clone https://github.com/sgumirov/opay-ussd.git
 cd opay-ussd
+```
+
+There are two options:
+- Local run (requires NodeJS v16)
+- Dockerized run (obviously, requires only Docker)
+
+### Local run
+
+```
 npm ci
 npm start
 ```
@@ -39,11 +48,39 @@ npm start
 This makes service uses default `3000` port on ipv4 Localhost. So better to use nginx or change
 listening address to 0.0.0.0 by changing line in `package.json`:
 ```
-    "start": "micro -H 127.0.0.1 index.js"
+    "start": "micro -l tcp://127.0.0.1:3000 index.js"
 ```
-to:
+to (by default the endpoint is: `0.0.0.0:3000`):
 ```
-    "start": "micro -H 0.0.0.0 index.js"
+    "start": "micro index.js"
+```
+
+### Dockerized run
+
+```
+docker build . -t opay-ussd
+docker run -p 3000:3000 opay-ussd
+```
+
+## Usage
+
+This service is designed to emulate GlobalUSSD USSD service. It can also work with Android GlobalUSSD emulator.
+
+Example of manual request and response, just to give some perspective (note `index.xml` in url, can also query other mentioned xmls from response):
+
+```
+$ curl http://127.0.0.1:3000/index.xml
+<page version="2.0">
+    <div protocol="ussd">
+Welcome to OPay.
+    </div>
+    <navigation>
+        <link accesskey="1" pageId="pin-airtime.xml">Airtime</link>
+        <link accesskey="2" pageId="pin-send.xml">Send money</link>
+        <link accesskey="3" pageId="otp.xml">Generate OTP</link>
+        <link accesskey="4" pageId="pin-balance.xml">My Balance</link>
+    </navigation>
+</page>
 ```
 
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Built on top of [micro](https://github.com/zeit/micro "micro") microservice fram
 
 # Author
 
-Shamil Gumirov, 2017-2019.
+(C) Copyright by Shamil Gumirov, 2017-2023.
 
-Disclaimer: I'm first PM of GlobalUSSD (aka SADS) project (started circa 2005).
+Disclaimer: I had been a teamlead of GlobalUSSD (aka SADS) project in 2005-2010.
 Feel free to reach me if you have questions.
 
 # License

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is demo USSD service for OPay based on SADS Eyeline platform.",
   "main": "index.js",
   "scripts": {
-    "start": "micro -H 127.0.0.1 index.js"
+    "start": "micro -l tcp://127.0.0.1:3000 index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This patch addresses the issue reported by Ippez Robert (@Ippezrobert):

> tried to run it but it failed with some errors such as `Error: Unknown or unexpected option: -H`. 

Start flags were changed in `micro` framework. This patch fixes it.

Thanks for taking time to report it, Robert!